### PR TITLE
Integration with Sonar

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ License
 -------
 
 ```
-Copyright (c) 2013-2015 Futurice Ltd
+Copyright (c) 2013-2014 Futurice Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ After this you should be able to add `Publish JUnit test result report` in your 
 
 After all this setting up, just click `Save` and start building, you should get all errors nicely both to the console log as the tests are being run and finally to the Jenkins reports.
 
+SonarQube Integration
+---------------------
+
+[SonarQube](http://www.sonarqube.org/) is a popular tool for continuous inspection of code quality. You can find documentation for JavaScript language on [JavaScript Plugin](http://docs.sonarqube.org/display/SONAR/JavaScript+Plugin) page.
+
+One aspect of SonarQube analysis is outcome of unit tests. To properly display tests results environment variable `JENKINS_REPORTER_ENABLE_SONAR` must be set to `true`. By default reporter looks for tests in `./test` directory. It can be changed using environment variable `JENKINS_REPORTER_TEST_DIR` and providing relative path to the directory with tests.
+
 License
 -------
 

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -74,7 +74,7 @@ function Jenkins(runner) {
     } else {
       currentSuite.tests.forEach(function(test) {
         writeString('<testcase');
-        writeString(' classname="'+htmlEscape(currentSuite.suite.fullTitle())+'"');
+        writeString(' classname="'+getClassName(test, currentSuite.suite)+'"');
         writeString(' name="'+htmlEscape(test.title)+'"');
         writeString(' time="'+(test.duration/1000)+'"');
         if (test.state == "failed") {
@@ -181,6 +181,17 @@ function Jenkins(runner) {
     }
 
     return msg;
+  }
+
+  function getClassName(test, suite) {
+    if (process.env.JENKINS_REPORTER_ENABLE_SONAR) {
+      // Inspired by https://github.com/pghalliday/mocha-sonar-reporter
+      var relativeTestDir = process.env.JENKINS_REPORTER_TEST_DIR || 'test',
+          absoluteTestDir = path.join(process.cwd(), relativeTestDir),
+          relativeFilePath = path.relative(absoluteTestDir, test.file);
+      return relativeFilePath.replace('.js', '');
+    }
+    return htmlEscape(suite.fullTitle());
   }
 
   runner.on('start', function() {

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -189,7 +189,7 @@ function Jenkins(runner) {
       var relativeTestDir = process.env.JENKINS_REPORTER_TEST_DIR || 'test',
           absoluteTestDir = path.join(process.cwd(), relativeTestDir),
           relativeFilePath = path.relative(absoluteTestDir, test.file);
-      return relativeFilePath.replace('.js', '');
+      return relativeFilePath.replace(/\.js$/, '');
     }
     return htmlEscape(suite.fullTitle());
   }


### PR DESCRIPTION
Hello there,

First of all, thank you for your work on mocha-jenkins-reporter. I find colored console output especially charming :)

In this pull request I would like to propose a little addition to your reporter which can extend its capabilities significantly. It is integration with Sonar, a quite popular tool responsible for static code analysis in continuous integration process. Unfortunately, the output generated by your reporter is not compatible with Sonar expectations. The only required change is to generate relative path to a test file and assign it to classname property.

There is already a reporter for Sonar (https://github.com/pghalliday/mocha-sonar-reporter) but first of all the project is not very active and secondly there is no support for colored console output :)

Please take a look at my commit and decide if it can be merged with your repository. If you find it worth then I will add some documentation for that feature.

Kind regards,
Tomasz